### PR TITLE
Implement interactive intro flow and difficulty selection system

### DIFF
--- a/spellventure/.gitignore
+++ b/spellventure/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/spellventure/index.html
+++ b/spellventure/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spellventure</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #f9fafb;
+        overflow: hidden;
+        font-family: system-ui, sans-serif;
+      }
+      #container {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/spellventure/package.json
+++ b/spellventure/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "spellventure",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "konva": "^9.3.3"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^7.1.7"
+  }
+}

--- a/spellventure/src/App.ts
+++ b/spellventure/src/App.ts
@@ -1,0 +1,130 @@
+// src/App.ts
+import Konva from "konva";
+import type { Screen, ScreenSwitcher } from "./types";
+
+import MenuScreenController from "./controllers/MenuScreenController";
+import GameScreenController from "./controllers/GameScreenController";
+import ResultsScreenController from "./controllers/ResultsScreenController";
+import DifficultyScreenController from "./controllers/DifficultyScreenController";
+import NavBarController from "./controllers/NavBarController";
+import HelpModalController from "./controllers/HelpModalController";
+
+export default class App implements ScreenSwitcher {
+    private helpClosedOnce = false;
+    private stage: Konva.Stage;
+    private layer: Konva.Layer;
+
+  // Screens
+    private menuController: MenuScreenController;
+    private difficultyController: DifficultyScreenController;
+    private gameController: GameScreenController;
+    private resultsController: ResultsScreenController;
+
+  // Global UI
+    private navBarController: NavBarController;
+    private helpModalController: HelpModalController;
+
+  // Simple history stack for Back behavior
+    private history: Screen[] = [];
+
+    constructor(stage: Konva.Stage, layer: Konva.Layer) {
+        this.stage = stage;
+        this.layer = layer;
+
+    // Instantiate controllers
+    this.menuController = new MenuScreenController(this);
+    this.difficultyController = new DifficultyScreenController(this);
+    this.gameController = new GameScreenController(this);
+    this.resultsController = new ResultsScreenController(this);
+
+    this.navBarController = new NavBarController(this);
+    this.helpModalController = new HelpModalController(this);
+
+    // Add groups to the shared layer (z-order = add order)
+    // 1) Screens (bottom)
+    this.layer.add(this.menuController.getView().getGroup());
+    this.layer.add(this.difficultyController.getView().getGroup());
+    this.layer.add(this.gameController.getView().getGroup());
+    this.layer.add(this.resultsController.getView().getGroup());
+    // 2) Nav bar (always on top of screens)
+    this.layer.add(this.navBarController.getView().getGroup());
+    // 3) Help modal (overlay above nav + screens)
+    this.layer.add(this.helpModalController.getView().getGroup());
+
+    this.stage.add(this.layer);
+
+    // Initial state: Menu + auto-open Help once
+    this.switchToScreen({ type: "menu" }, false);
+    this.openHelp(); // auto show instructions on first load
+  }
+
+  // ===== ScreenSwitcher API =====
+  switchToScreen(screen: Screen, pushToHistory: boolean = true): void {
+    // Hide all screens first
+    this.menuController.hide();
+    this.difficultyController.hide();
+    this.gameController.hide();
+    this.resultsController.hide();
+
+    // Show target screen
+    switch (screen.type) {
+      case "menu":
+        this.menuController.show();
+        break;
+      case "difficulty":
+        this.difficultyController.show();
+        break;
+      case "game":
+        this.gameController.show();
+        break;
+      case "result":
+        this.resultsController.show();
+        break;
+      default:
+        console.warn(`Unknown screen: ${screen.type}`);
+    }
+
+    // Always show nav bar (global HUD)
+    this.navBarController.show();
+
+    // Manage history stack (don’t push when we’re doing a replace-like navigation)
+    if (pushToHistory) this.history.push(screen);
+
+    this.layer.draw();
+  }
+
+  goBack(): void {
+    // Need at least 2 entries to go back (current + previous)
+    if (this.history.length <= 1) {
+      // If no history to go back to, go home
+      this.goHome();
+      return;
+    }
+    // Pop current
+    this.history.pop();
+    // Show previous without pushing again
+    const prev = this.history[this.history.length - 1];
+    this.switchToScreen(prev, false);
+  }
+
+  goHome(): void {
+    this.history = [];
+    this.switchToScreen({ type: "menu" }, true);
+  }
+
+  openHelp(): void {
+    this.helpModalController.show();
+    this.layer.draw();
+  }
+
+  closeHelp(): void {
+  this.helpModalController.hide();
+  this.layer.draw();
+
+  if (!this.helpClosedOnce) {
+    this.helpClosedOnce = true;
+    // Start the “assemble PLAY” intro
+    this.menuController.startPlayIntro();
+  }
+ }
+}

--- a/spellventure/src/controllers/DifficultyScreenController.ts
+++ b/spellventure/src/controllers/DifficultyScreenController.ts
@@ -1,0 +1,32 @@
+// src/controllers/DifficultyScreenController.ts
+import DifficultyScreenView from "../views/DifficultyScreenView";
+import type { ScreenSwitcher } from "../types";
+import { GameState } from "../state/GameState";
+
+export default class DifficultyScreenController {
+  private view: DifficultyScreenView;
+  private app: ScreenSwitcher;
+
+  constructor(app: ScreenSwitcher) {
+    this.app = app;
+    this.view = new DifficultyScreenView();
+
+    this.view.onDifficultySelected((level) => {
+      const state = GameState.load();
+      state.setDifficulty(level as "easy" | "medium" | "hard");
+      this.app.switchToScreen({ type: "game" });
+    });
+  }
+
+  getView(): DifficultyScreenView {
+    return this.view;
+  }
+
+  show(): void {
+    this.view.show();
+  }
+
+  hide(): void {
+    this.view.hide();
+  }
+}

--- a/spellventure/src/controllers/GameScreenController.ts
+++ b/spellventure/src/controllers/GameScreenController.ts
@@ -1,0 +1,37 @@
+// src/controllers/GameScreenController.ts
+import Konva from "konva";
+import type { ScreenSwitcher } from "../types";
+
+export default class GameScreenController {
+  private group: Konva.Group;
+  private app: ScreenSwitcher;
+
+  constructor(app: ScreenSwitcher) {
+    this.app = app;
+    this.group = new Konva.Group();
+
+    const text = new Konva.Text({
+      text: "Game Screen (placeholder)",
+      fontSize: 32,
+      fill: "#333",
+      x: window.innerWidth / 2 - 200,
+      y: window.innerHeight / 2 - 20,
+      width: 400,
+      align: "center",
+    });
+
+    this.group.add(text);
+  }
+
+  getView() {
+    return { getGroup: () => this.group };
+  }
+
+  show() {
+    this.group.visible(true);
+  }
+
+  hide() {
+    this.group.visible(false);
+  }
+}

--- a/spellventure/src/controllers/HelpModalController.ts
+++ b/spellventure/src/controllers/HelpModalController.ts
@@ -1,0 +1,25 @@
+import HelpModalView from "../views/HelpModalView";
+import type { ScreenSwitcher } from "../types";
+
+export default class HelpModalController {
+  private view: HelpModalView;
+  private app: ScreenSwitcher;
+
+  constructor(app: ScreenSwitcher) {
+    this.app = app;
+    this.view = new HelpModalView();
+    this.view.onClose(() => this.app.closeHelp());
+  }
+
+  getView() {
+    return this.view;
+  }
+
+  show() {
+    this.view.show();
+  }
+
+  hide() {
+    this.view.hide();
+  }
+}

--- a/spellventure/src/controllers/MenuScreenController.ts
+++ b/spellventure/src/controllers/MenuScreenController.ts
@@ -1,0 +1,32 @@
+// src/controllers/MenuScreenController.ts
+import MenuScreenView from "../views/MenuScreenView";
+import type { ScreenSwitcher } from "../types";
+
+export default class MenuScreenController {
+  private view: MenuScreenView;
+  private app: ScreenSwitcher;
+
+  constructor(app: ScreenSwitcher) {
+    this.app = app;
+    this.view = new MenuScreenView();
+  }
+
+  getView(): MenuScreenView {
+    return this.view;
+  }
+
+  startPlayIntro(): void {
+    this.view.startPlayIntro(() => {
+      // When user completes “PLAY” word:
+      this.app.switchToScreen({ type: "difficulty" });
+    });
+  }
+
+  show(): void {
+    this.view.show();
+  }
+
+  hide(): void {
+    this.view.hide();
+  }
+}

--- a/spellventure/src/controllers/NavBarController.ts
+++ b/spellventure/src/controllers/NavBarController.ts
@@ -1,0 +1,28 @@
+import NavBarView from "../views/NavBarView";
+import type { ScreenSwitcher } from "../types";
+
+export default class NavBarController {
+  private view: NavBarView;
+  private app: ScreenSwitcher;
+
+  constructor(app: ScreenSwitcher) {
+    this.app = app;
+    this.view = new NavBarView();
+
+    this.view.onHomeClick(() => this.app.goHome());
+    this.view.onBackClick(() => this.app.goBack());
+    this.view.onHelpClick(() => this.app.openHelp());
+  }
+
+  getView() {
+    return this.view;
+  }
+
+  show() {
+    this.view.show();
+  }
+
+  hide() {
+    this.view.hide();
+  }
+}

--- a/spellventure/src/controllers/ResultsScreenController.ts
+++ b/spellventure/src/controllers/ResultsScreenController.ts
@@ -1,0 +1,37 @@
+// src/controllers/ResultsScreenController.ts
+import Konva from "konva";
+import type { ScreenSwitcher } from "../types";
+
+export default class ResultsScreenController {
+  private group: Konva.Group;
+  private app: ScreenSwitcher;
+
+  constructor(app: ScreenSwitcher) {
+    this.app = app;
+    this.group = new Konva.Group();
+
+    const text = new Konva.Text({
+      text: "Results Screen (placeholder)",
+      fontSize: 32,
+      fill: "#333",
+      x: window.innerWidth / 2 - 200,
+      y: window.innerHeight / 2 - 20,
+      width: 400,
+      align: "center",
+    });
+
+    this.group.add(text);
+  }
+
+  getView() {
+    return { getGroup: () => this.group };
+  }
+
+  show() {
+    this.group.visible(true);
+  }
+
+  hide() {
+    this.group.visible(false);
+  }
+}

--- a/spellventure/src/main.ts
+++ b/spellventure/src/main.ts
@@ -1,0 +1,26 @@
+import Konva from "konva";
+import App from "./App";
+
+// Create the Konva stage
+const stage = new Konva.Stage({
+  container: "container", // this matches the div id in index.html
+  width: window.innerWidth,
+  height: window.innerHeight,
+});
+
+// Create a single layer (all screens will share this)
+const layer = new Konva.Layer();
+stage.add(layer);
+
+// Initialize the main app controller
+const app = new App(stage, layer);
+
+// Start the app on the menu/home screen
+app.switchToScreen({ type: "menu" });
+
+// Optional: keep the canvas responsive
+window.addEventListener("resize", () => {
+  stage.width(window.innerWidth);
+  stage.height(window.innerHeight);
+  stage.draw();
+});

--- a/spellventure/src/state/GameState.ts
+++ b/spellventure/src/state/GameState.ts
@@ -1,0 +1,62 @@
+// src/state/GameState.ts
+// Manages persistent state such as difficulty, score, and progress.
+// Uses localStorage for persistence between sessions.
+
+export type Difficulty = "easy" | "medium" | "hard";
+
+export class GameState {
+  private static instance: GameState;
+  private difficulty: Difficulty = "easy";
+  private score: number = 0;
+
+  // Singleton pattern
+  static load(): GameState {
+    if (!GameState.instance) {
+      const saved = localStorage.getItem("spellventure_state");
+      if (saved) {
+        const data = JSON.parse(saved);
+        const gs = new GameState();
+        gs.difficulty = data.difficulty ?? "easy";
+        gs.score = data.score ?? 0;
+        GameState.instance = gs;
+      } else {
+        GameState.instance = new GameState();
+      }
+    }
+    return GameState.instance;
+  }
+
+  setDifficulty(level: Difficulty) {
+    this.difficulty = level;
+    this.save();
+  }
+
+  getDifficulty(): Difficulty {
+    return this.difficulty;
+  }
+
+  addScore(points: number) {
+    this.score += points;
+    this.save();
+  }
+
+  getScore(): number {
+    return this.score;
+  }
+
+  reset() {
+    this.difficulty = "easy";
+    this.score = 0;
+    this.save();
+  }
+
+  private save() {
+    localStorage.setItem(
+      "spellventure_state",
+      JSON.stringify({
+        difficulty: this.difficulty,
+        score: this.score,
+      })
+    );
+  }
+}

--- a/spellventure/src/types.ts
+++ b/spellventure/src/types.ts
@@ -1,0 +1,10 @@
+// src/types.ts
+export type Screen = { type: "menu" | "difficulty" | "game" | "result" };
+
+export interface ScreenSwitcher {
+  switchToScreen(screen: Screen, pushToHistory?: boolean): void; // default true
+  goBack(): void;
+  goHome(): void;
+  openHelp(): void;
+  closeHelp(): void;
+}

--- a/spellventure/src/views/DifficultyScreenView.ts
+++ b/spellventure/src/views/DifficultyScreenView.ts
@@ -1,0 +1,80 @@
+// src/views/DifficultyScreenView.ts
+import Konva from "konva";
+
+export default class DifficultyScreenView {
+  private group: Konva.Group;
+  private buttons: Record<string, Konva.Rect> = {};
+  private labels: Record<string, Konva.Text> = {};
+
+  constructor() {
+    this.group = new Konva.Group();
+
+    const title = new Konva.Text({
+      text: "Choose Difficulty",
+      fontSize: 48,
+      fontFamily: "Arial",
+      fill: "#1e1e1e",
+      x: window.innerWidth / 2 - 200,
+      y: window.innerHeight / 4,
+      width: 400,
+      align: "center",
+    });
+    this.group.add(title);
+
+    const levels = ["Easy", "Medium", "Hard"];
+    const colors = ["#22c55e", "#eab308", "#ef4444"];
+
+    levels.forEach((lvl, i) => {
+      const x = window.innerWidth / 2 - 150;
+      const y = window.innerHeight / 2 - 100 + i * 120;
+
+      const rect = new Konva.Rect({
+        x,
+        y,
+        width: 300,
+        height: 80,
+        cornerRadius: 20,
+        fill: colors[i],
+        shadowColor: "rgba(0,0,0,0.3)",
+        shadowBlur: 8,
+      });
+
+      const label = new Konva.Text({
+        text: lvl,
+        fontSize: 32,
+        fill: "#ffffff",
+        width: 300,
+        align: "center",
+        x,
+        y: y + 22,
+      });
+
+      this.buttons[lvl.toLowerCase()] = rect;
+      this.labels[lvl.toLowerCase()] = label;
+
+      this.group.add(rect);
+      this.group.add(label);
+    });
+  }
+
+  getGroup(): Konva.Group {
+    return this.group;
+  }
+
+  onDifficultySelected(handler: (level: string) => void): void {
+    Object.keys(this.buttons).forEach((key) => {
+      const rect = this.buttons[key];
+      const label = this.labels[key];
+      rect.on("click tap", () => handler(key));
+      label.on("click tap", () => handler(key));
+    });
+  }
+
+  show(): void {
+    this.group.visible(true);
+  }
+
+  hide(): void {
+    this.group.visible(false);
+  }
+}

--- a/spellventure/src/views/GameScreenView.ts
+++ b/spellventure/src/views/GameScreenView.ts
@@ -1,0 +1,37 @@
+// src/controllers/GameScreenController.ts
+import Konva from "konva";
+import type { ScreenSwitcher } from "../types";
+
+export default class GameScreenController {
+  private group: Konva.Group;
+  private app: ScreenSwitcher;
+
+  constructor(app: ScreenSwitcher) {
+    this.app = app;
+    this.group = new Konva.Group();
+
+    const text = new Konva.Text({
+      text: "Game Screen (placeholder)",
+      fontSize: 32,
+      fill: "#333",
+      x: window.innerWidth / 2 - 200,
+      y: window.innerHeight / 2 - 20,
+      width: 400,
+      align: "center",
+    });
+
+    this.group.add(text);
+  }
+
+  getView() {
+    return { getGroup: () => this.group };
+  }
+
+  show() {
+    this.group.visible(true);
+  }
+
+  hide() {
+    this.group.visible(false);
+  }
+}

--- a/spellventure/src/views/HelpModalView.ts
+++ b/spellventure/src/views/HelpModalView.ts
@@ -1,0 +1,99 @@
+// src/views/HelpModalView.ts
+import Konva from "konva";
+
+export default class HelpModalView {
+  private group: Konva.Group;
+  private background: Konva.Rect;
+  private box: Konva.Rect;
+  private title: Konva.Text;
+  private text: Konva.Text;
+  private closeButton: Konva.Text;
+
+  constructor() {
+    this.group = new Konva.Group({ visible: false });
+
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    // Semi-transparent dark background
+    this.background = new Konva.Rect({
+      x: 0,
+      y: 0,
+      width,
+      height,
+      fill: "rgba(0,0,0,0.5)",
+    });
+
+    // Main modal box
+    this.box = new Konva.Rect({
+      x: width / 2 - 280,
+      y: height / 2 - 200,
+      width: 560,
+      height: 360,
+      fill: "#ffffff",
+      cornerRadius: 20,
+      shadowColor: "black",
+      shadowBlur: 10,
+    });
+
+    this.title = new Konva.Text({
+      text: "Welcome to Spellventure!",
+      fontSize: 32,
+      fontFamily: "Arial",
+      fill: "#1e1e1e",
+      x: width / 2 - 250,
+      y: height / 2 - 170,
+      width: 500,
+      align: "center",
+    });
+
+    this.text = new Konva.Text({
+      text:
+        "How to Play:\n\n" +
+        "• To begin the game, drag the letters below to correctly spell “PLAY”.\n" +
+        "• Once the word is complete, you’ll move on to choose your difficulty.\n" +
+        "• Easy, Medium, and Hard levels change how much help you get.\n\n" +
+        "Tips:\n" +
+        "• You start with 3 hearts.\n" +
+        "• Correct spelling and longer words earn more points.\n" +
+        "• You can reopen this Help screen anytime by clicking the ❓ icon.",
+      fontSize: 20,
+      fontFamily: "Arial",
+      fill: "#222",
+      x: width / 2 - 260,
+      y: height / 2 - 120,
+      width: 520,
+      lineHeight: 1.4,
+      align: "left",
+    });
+
+    this.closeButton = new Konva.Text({
+      text: "✖ Close",
+      fontSize: 22,
+      fill: "#1e1e1e",
+      x: width / 2 + 180,
+      y: height / 2 + 120,
+      width: 100,
+      align: "center",
+    });
+
+    this.group.add(this.background, this.box, this.title, this.text, this.closeButton);
+  }
+
+  getGroup(): Konva.Group {
+    return this.group;
+  }
+
+  onClose(handler: () => void): void {
+    this.closeButton.on("click tap", handler);
+    this.background.on("click tap", handler);
+  }
+
+  show(): void {
+    this.group.visible(true);
+  }
+
+  hide(): void {
+    this.group.visible(false);
+  }
+}

--- a/spellventure/src/views/MenuScreenView.ts
+++ b/spellventure/src/views/MenuScreenView.ts
@@ -1,0 +1,96 @@
+// src/views/MenuScreenView.ts
+import Konva from "konva";
+
+export default class MenuScreenView {
+  private group: Konva.Group;
+  private targetGroup: Konva.Group;
+  private letterGroup: Konva.Group;
+  private targets: Konva.Text[] = [];
+  private letters: Konva.Text[] = [];
+
+  constructor() {
+    this.group = new Konva.Group();
+    this.targetGroup = new Konva.Group();
+    this.letterGroup = new Konva.Group();
+    this.group.add(this.targetGroup);
+    this.group.add(this.letterGroup);
+
+    // “PLAY” silhouette
+    const word = "PLAY";
+    const startX = window.innerWidth / 2 - 160;
+    const startY = window.innerHeight / 3;
+
+    for (let i = 0; i < word.length; i++) {
+      const t = new Konva.Text({
+        text: word[i],
+        fontSize: 100,
+        fontFamily: "Arial",
+        fill: "rgba(0,0,0,0.1)", // silhouette color
+        x: startX + i * 80,
+        y: startY,
+        width: 80,
+        align: "center",
+      });
+      this.targetGroup.add(t);
+      this.targets.push(t);
+    }
+
+    // Draggable letters at bottom
+    const bottomY = window.innerHeight - 150;
+    for (let i = 0; i < word.length; i++) {
+      const l = new Konva.Text({
+        text: word[i],
+        fontSize: 90,
+        fontFamily: "Arial",
+        fill: "#4f46e5",
+        x: startX + i * 100,
+        y: bottomY,
+        draggable: true,
+        shadowColor: "rgba(0,0,0,0.3)",
+        shadowBlur: 8,
+      });
+      this.letterGroup.add(l);
+      this.letters.push(l);
+    }
+  }
+
+  getGroup(): Konva.Group {
+    return this.group;
+  }
+
+  // Called from controller when starting intro
+  startPlayIntro(onComplete: () => void) {
+    let correct = 0;
+
+    this.letters.forEach((letter, i) => {
+      letter.on("dragend", () => {
+        const target = this.targets[i];
+        const dx = Math.abs(letter.x() - target.x());
+        const dy = Math.abs(letter.y() - target.y());
+
+        // Snap if close enough
+        if (dx < 40 && dy < 40) {
+          letter.position({ x: target.x(), y: target.y() });
+          letter.draggable(false);
+          letter.fill("#16a34a"); // turns green
+          correct++;
+
+          if (correct === this.letters.length) {
+            // All correct
+            setTimeout(() => {
+              onComplete();
+            }, 800);
+          }
+        }
+      });
+    });
+  }
+
+  show(): void {
+    this.group.visible(true);
+  }
+
+  hide(): void {
+    this.group.visible(false);
+  }
+}

--- a/spellventure/src/views/NavBarView.ts
+++ b/spellventure/src/views/NavBarView.ts
@@ -1,0 +1,76 @@
+import Konva from "konva";
+
+export default class NavBarView {
+  private group: Konva.Group;
+  private homeButton: Konva.Text;
+  private backButton: Konva.Text;
+  private helpButton: Konva.Text;
+  private bg: Konva.Rect;
+
+  constructor() {
+    this.group = new Konva.Group();
+
+    const barHeight = 60;
+
+    // background bar
+    this.bg = new Konva.Rect({
+      x: 0,
+      y: 0,
+      width: window.innerWidth,
+      height: barHeight,
+      fill: "#1e1e1e",
+      opacity: 0.9,
+    });
+
+    this.homeButton = new Konva.Text({
+      text: "🏠 Home",
+      fontSize: 20,
+      fill: "#ffffff",
+      x: 20,
+      y: 18,
+    });
+
+    this.backButton = new Konva.Text({
+      text: "← Back",
+      fontSize: 20,
+      fill: "#ffffff",
+      x: 130,
+      y: 18,
+    });
+
+    this.helpButton = new Konva.Text({
+      text: "❓ Help",
+      fontSize: 20,
+      fill: "#ffffff",
+      x: window.innerWidth - 100,
+      y: 18,
+    });
+
+    this.group.add(this.bg, this.homeButton, this.backButton, this.helpButton);
+    this.group.visible(true);
+  }
+
+  getGroup() {
+    return this.group;
+  }
+
+  onHomeClick(handler: () => void) {
+    this.homeButton.on("click tap", handler);
+  }
+
+  onBackClick(handler: () => void) {
+    this.backButton.on("click tap", handler);
+  }
+
+  onHelpClick(handler: () => void) {
+    this.helpButton.on("click tap", handler);
+  }
+
+  show() {
+    this.group.visible(true);
+  }
+
+  hide() {
+    this.group.visible(false);
+  }
+}

--- a/spellventure/src/views/ResultsScreenView.ts
+++ b/spellventure/src/views/ResultsScreenView.ts
@@ -1,0 +1,37 @@
+// src/controllers/ResultsScreenController.ts
+import Konva from "konva";
+import type { ScreenSwitcher } from "../types";
+
+export default class ResultsScreenController {
+  private group: Konva.Group;
+  private app: ScreenSwitcher;
+
+  constructor(app: ScreenSwitcher) {
+    this.app = app;
+    this.group = new Konva.Group();
+
+    const text = new Konva.Text({
+      text: "Results Screen (placeholder)",
+      fontSize: 32,
+      fill: "#333",
+      x: window.innerWidth / 2 - 200,
+      y: window.innerHeight / 2 - 20,
+      width: 400,
+      align: "center",
+    });
+
+    this.group.add(text);
+  }
+
+  getView() {
+    return { getGroup: () => this.group };
+  }
+
+  show() {
+    this.group.visible(true);
+  }
+
+  hide() {
+    this.group.visible(false);
+  }
+}

--- a/spellventure/tsconfig.json
+++ b/spellventure/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client", "konva"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting / Strictness */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Added draggable 'PLAY' intro sequence to replace static start button 
Integrated Help modal with new onboarding instructions (auto-opens on load) 
Implemented DifficultyScreenView and controller for Easy/Medium/Hard selection
Connected GameState persistence to store selected difficulty 
Cleaned App.ts for proper screen management, history, and Help flow
Verified flow: Help → PLAY intro → Difficulty screen → Game screen